### PR TITLE
Pytest setup and dev env build fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
           ]
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
+.PHONY: dev
+export PIPENV_VENV_IN_PROJECT := 1
+
 # Default make target
 init: hwstats
 
 # Make target to build a development environment
 dev:
 	@echo "Building development environment"
-	export PIPENV_VENV_IN_PROJECT
 	pip install pipenv
 	pipenv install --dev
 	pipenv run pip install --upgrade pip

--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,7 @@ pylint = "*"
 pyinstaller = "*"
 setuptools-scm = "*"
 build = "*"
-#hwstats = {editable = true, path = "."}
+hwstats = {editable = true, path = "."}
 pytest = "*"
 pytest-cov = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c72d28513612abb81ba1bbbd343f9b3ba8cdd6e44842d173aeae25dc5ebc4771"
+            "sha256": "7c013efb1323b10f3970e3115becfdc08a435675630e666e39e6967b507c002e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -192,50 +192,50 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:013f4f330001e84a2b0ef1f2c9bd73169c79d582e54e1a144be1be1dbc911711",
-                "sha256:0789e199fbce8cb1775337afc631ed12bcc5463dd77d7a06b8dafd758cde51f8",
-                "sha256:0b698440c477c00bdedff87348b19a79630a235864a8f4378098d61079c16ce9",
-                "sha256:0eac488be90dd3f7a655d2e34fa59e1305fccabc4abfbd002e3a72ae10bd2f89",
-                "sha256:14854bdb2a35af536d14f77dfa8dbc20e1bb1972996d64c4147e0d3165c9aaf5",
-                "sha256:18795e87601b4244fd08b542cd6bff9ef674b17bcd34e4a3c9935398e2cc762c",
-                "sha256:32f508fef9c5a7d19411d94ef64cf5405e42c4689e51ddbb81ac9a7be045cce8",
-                "sha256:33f73cc45ffa050f5c3b60ff4490e0ae9e02701461c1600d5ede1b008076b1b9",
-                "sha256:38e26cf6b9b4c6c37846f7e31b42e4d664b35f055691265f07e06aeb6167c494",
-                "sha256:3da3dff8d9833a7d7f66a3c45a79a3955f775c79f47bb7eea266d0b4c267b17a",
-                "sha256:432cfd77642771ee7ea0dd0f3fb664f18506a3625eab6e6d5d1d771569171270",
-                "sha256:4339110be209fea37a2bb4f35f1127c7562a0393e9e6df5d9a65cc4f5c167cb6",
-                "sha256:486015a58c9a67f65a15b4f19468b35b97cee074ae55386a9c240f1da308fbfe",
-                "sha256:494db0026918e3f707466a1200a5dedbf254a4bce01a3115fd95f04ba8258f09",
-                "sha256:57b80e877eb6ec63295835f8a3b86ca3a44829f80c4748e1b019e03adea550fc",
-                "sha256:5f7c40ec2e3b31293184020daba95850832bea523a08496ac89b27a5276ec804",
-                "sha256:6d44ff7573016fc26311b5a5c54d5656fb9e0c39e138bc8b81cb7c8667485203",
-                "sha256:774965c41b71c8ebe3c5728bf5b9a948231fc3a0422d9fdace0686f5bb689ad6",
-                "sha256:7917632606fc5d4be661dcde45cc415df835e594e2c50cc999a44f24b6bf6d92",
-                "sha256:9020125e3be677c64d4dda7048e247343f1663089cf268a4cc98c957adb7dbe0",
-                "sha256:921485d1f69ed016e1f756de67d02ad4f143eb6b92b9776bfff78786d8978ab5",
-                "sha256:94556a2a7fc3de094ea056b62845e2e6e271e26d1e1b2540a1cd2d2506257a10",
-                "sha256:a4c1e1582492c66dfacc9eab52738f3e64d9a2a380e412668f75aa06e540f649",
-                "sha256:a65a8fd09bdffd63fa23b39cd902e6a4ca23d86ecfe129513e43767a1f3e91fb",
-                "sha256:a6f7d1debb233f1567d700ebcdde0781a0b63db0ef266246dfbf75ae41bfdf85",
-                "sha256:b0995b92612979d208189245bf87349ad9243b97b49652347a28ddee0803225a",
-                "sha256:b8ab8f90f4a13c979e6c41c9f011b655c1b9ae2df6cffa8fa2c7c4d740f3512e",
-                "sha256:bc370d53fee7408330099c4bcc2573a107757b203bc61f114467dfe586a0c7bd",
-                "sha256:c38641f5c3714505d65dbbd8fb1350408b9ad8461769ec8e440e1177f9c92d1d",
-                "sha256:cc337b96ec59ef29907eeadc2ac11188739281568f14c719e61550ca6d201a41",
-                "sha256:ce076e25f1170000b4ecdc57a1ff8a70dbe4a5648ec3da0563ef3064e8db4f15",
-                "sha256:cebd161f964af58290596523c65e41a5a161a99f7212b1ae675e288a4b5e0a7c",
-                "sha256:d2e7411d5ea164c6f4d003f5d4f5e72e202956aaa7496b95bb4a4c39669e001c",
-                "sha256:e735a635126b2338dfd3a0863b675437cb53d85885a7602b8cffb24345df33ed",
-                "sha256:e7e61e2e4dfe175dc3510889e44eda1c32f55870d6950ef40519640cb266704d",
-                "sha256:e90f0be674e0845c5c1ccfa5e31c9ee28fd406546a61afc734355cc7ea1f8f8b",
-                "sha256:ea1c63e61b5c13161c8468305f0a5837c80aae2070e33654c68dd12572b638eb",
-                "sha256:ea9461f6955f3cf9eff6eeec271686caed7792c76f5b966886a36a42ea46e6b2",
-                "sha256:f15c54713a8dd57a01c974c9f96476688f6f6374d348819ed7e459535844b614",
-                "sha256:fb649c5473f79c9a7b6133f53a31f4d87de14755c79224007eb7ec76e628551e",
-                "sha256:fc67667c8e8c04e5c3250ab2cd51df40bc7c28c7c253d0475b377eff86fe4bb0"
+                "sha256:09b6a94bbb1507b3fc75a3c98491f990b80a859eb5227378f6dac908dff74396",
+                "sha256:0cdc65cbb95ae6813c51acffa65dd8d8272a52da42e3967fc98788fe185a0e0c",
+                "sha256:21698ac65afe477400aacb56244b607477c192892e2f7a70492cae1e13f73040",
+                "sha256:250e158a1f36c965dde1f949366eae9a57504a8cd7a4d968e66c2d0b3c18198d",
+                "sha256:2cc70331b7aed25fed5260cf30a69e42eaf3d887a23a6e4f29a51167ae8a00e1",
+                "sha256:32af8923cfe7b115d40b88604412450d2e4714f4b9a69b1966dfe6012e254789",
+                "sha256:337ae79dc63b1c957dd2e9e7eed5235492886e2af45d8df4b28748ee4859b588",
+                "sha256:3a1eb8ed5dc2a7bc554a612a57253f3682aea7e4c54c742153aef6a12fde10ee",
+                "sha256:3ca04c2ccf6f70278905a371ae6eb61494e8c388e98cba909bc9458ceb73dda5",
+                "sha256:42207a5237d8b211df1c04da4a8700bb9f366f5d7be14b1a2e39cc33d330428c",
+                "sha256:4223002ab7faac63384019feb31eab4ae2233753fd06ea95690d4e148b5bf80d",
+                "sha256:50fa610ac1e45e9adc161227cccbd5c75f8eef25b2ad4a0e080d48c27023415d",
+                "sha256:5a64345a6f41c8c011df3f498cee8de39d9682ca2de14698b68a50bf3a03f6e5",
+                "sha256:5b030f91dd310c0f1d7da0654fcc9d8574fe430693e29c544f5558c2426e08eb",
+                "sha256:68b328500a20f328db6af2c6839eb69e3791b2cd544f5808a4b0123b130c7571",
+                "sha256:692a2b1e0c82c678c84ccb3a9a226e0553dd115be3d5c54b1bb6ef35bc464da9",
+                "sha256:6a091b9166ab9d8ff77c3155140105e76df1d585632fb9367a31b517960df78a",
+                "sha256:6c5e056a6dc1ce29d5e0e54bc1ce669f3035ec18cb7e5c853122b5fdfe216f8f",
+                "sha256:6c8e546c249f0d23821f4b31e5adfba8e39bc90140d39f7086d4a8422d1f0fa6",
+                "sha256:6d82bb74a44f103d566f6c86d6db0ed944e99a7da93d6490c1e987a2b91d5613",
+                "sha256:6f33587541eb6eb0292e82b314f5ef53159f63f14ae1c08b5ef6195732523afa",
+                "sha256:7e0f74c66b2d0081cee5093150407ec43d23d0d5c70aa5b41f438ead1d39bc8d",
+                "sha256:81ada150345ef9c709b647e2bcc8f688d62de6b8f06a7544bed76bef328c6636",
+                "sha256:8a215d3e9de2af881c4eee60bf2b3576fb2eeb591a9af37ff2919cd74b68f162",
+                "sha256:8df6722580ff89295e9d11b781d7a50ff6e48fdfe1c81362000925b4d4cbab31",
+                "sha256:9a981a65dc0082009399eac6600b0983120bc3b850f3c1ed986f68648d9dbb4c",
+                "sha256:a1906c954ee7287d46877636a66da157fc83553851013e42c862653ddacb380b",
+                "sha256:aaf42183f93ad3801bc08c8a111de16802a2c32d16dcb9700daf1a8ae12d9d28",
+                "sha256:af0683c905c856db70adf6d0f84398785f7be6cb4ffdad20d8e16fe426bdf6e8",
+                "sha256:b3bdbd9a5b2788b5c51c4fffa2f875103d3c6d01b8f0dc4abbf075cea11741f5",
+                "sha256:b4c73a3537f928ebf687244f2af9d477b3b14640b4472fcb2456ee0193850ba1",
+                "sha256:c2590fd682d3b9dbecb2710ba83b28ba9df18e0c3c26c78bb950715566784723",
+                "sha256:cd405d224c0f83f267bfcc430bd275195cb48bb9576f6949911faec16bba1216",
+                "sha256:cf1447ec09d7c9ef0b3a65cea905690ed78ed88717beaac537271c005b0e4ea2",
+                "sha256:d6753512214d0de6a5a1c05fe716a7d643c927eb0495341db6526577960cbb55",
+                "sha256:d713d8c4b36c4f69eef33a70a4521e37b75a3ac9c86ee96626c4b052337978cc",
+                "sha256:e424a385a234e0bbaac69b6b09894ce99aa285518dd9397846e78214671ec0b4",
+                "sha256:e8707ba6e783d144209dab0324cc72147a1de34d404a61a08eef96fbb3c8909f",
+                "sha256:ea2976a98076f44e7e8ab9a90b6dfa357253edddf687294b1bcd852ffe20e526",
+                "sha256:f12cd526188f36f161eb71fb275b06d1879c565b07cf0ab2c2408c5059df1fed",
+                "sha256:fa72fb1be5e6704d697471eb5cc07bf9cd98689be11ffa724efe2a3666d0f6c1"
             ],
             "index": "pypi",
-            "version": "==2.0.7"
+            "version": "==2.0.8"
         },
         "typing-extensions": {
             "hashes": [
@@ -315,11 +315,11 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:89860bda98fe2bbd1f5d262229be7629d778ce280de68d95d4a73d1f592ad268",
-                "sha256:af4e0aff46e2868218502789898269ed95b663fba49e65d91c1e09c966266c34"
+                "sha256:6e61b85c891ec53b07471aec5878f4ac6446a41e590ede0f2ce095f39f7d49dd",
+                "sha256:dea89d9f99f491c66ac9c04ebddf91e4acf8bd711722175fe6245c0725cc19bb"
             ],
             "markers": "python_full_version >= '3.7.2'",
-            "version": "==2.15.1"
+            "version": "==2.15.2"
         },
         "asttokens": {
             "hashes": [
@@ -642,6 +642,10 @@
             ],
             "version": "==1.5.1"
         },
+        "hwstats": {
+            "editable": true,
+            "path": "."
+        },
         "identify": {
             "hashes": [
                 "sha256:f0faad595a4687053669c112004178149f6c326db71ee999ae4636685753ad2f",
@@ -955,19 +959,19 @@
         },
         "nbclient": {
             "hashes": [
-                "sha256:884a3f4a8c4fc24bb9302f263e0af47d97f0d01fe11ba714171b320c8ac09547",
-                "sha256:d97ac6257de2794f5397609df754fcbca1a603e94e924eb9b99787c031ae2e7c"
+                "sha256:26e41c6dca4d76701988bc34f64e1bfc2413ae6d368f13d7b5ac407efb08c755",
+                "sha256:8fa96f7e36693d5e83408f5e840f113c14a45c279befe609904dbe05dad646d1"
             ],
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==0.7.2"
+            "version": "==0.7.3"
         },
         "nbconvert": {
             "hashes": [
-                "sha256:8eed67bd8314f3ec87c4351c2f674af3a04e5890ab905d6bd927c05aec1cf27d",
-                "sha256:e41118f81698d3d59b3c7c2887937446048f741aba6c367c1c1a77810b3e2d08"
+                "sha256:8983a83d0b083d56b076019f0a319f63bc16af70c9372892b86a0aab0a264b1d",
+                "sha256:b970a13aba97529c223d805dd0706c2fe04dfc05e250ad4e6f7ae33daf6fede1"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==7.2.10"
+            "version": "==7.3.0"
         },
         "nbformat": {
             "hashes": [
@@ -1074,11 +1078,11 @@
         },
         "pre-commit": {
             "hashes": [
-                "sha256:a06a7fcce7f420047a71213c175714216498b49ebc81fe106f7716ca265f5bb6",
-                "sha256:b5aee7d75dbba21ee161ba641b01e7ae10c5b91967ebf7b2ab0dfae12d07e1f1"
+                "sha256:0b4210aea813fe81144e87c5a291f09ea66f199f367fa1df41b55e1d26e1e2b4",
+                "sha256:5b808fcbda4afbccf6d6633a56663fed35b6c2bc08096fd3d47ce197ac351d9d"
             ],
             "index": "pypi",
-            "version": "==3.2.1"
+            "version": "==3.2.2"
         },
         "prometheus-client": {
             "hashes": [
@@ -1174,11 +1178,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:8660a54e3f696243d644fca98f79013a959c03f979992c1ab59c24d3f4ec2700",
-                "sha256:d4d009b0116e16845533bc2163493d6681846ac725eab8ca8014afb520178ddd"
+                "sha256:001cc91366a7df2970941d7e6bbefcbf98694e00102c1f121c531a814ddc2ea8",
+                "sha256:1b647da5249e7c279118f657ca28b6aaebb299f86bf92affc632acf199f7adbb"
             ],
             "index": "pypi",
-            "version": "==2.17.1"
+            "version": "==2.17.2"
         },
         "pyproject-hooks": {
             "hashes": [
@@ -1384,11 +1388,11 @@
         },
         "qtconsole": {
             "hashes": [
-                "sha256:bae8c7e10170cdcdcaf7e6d53ad7d6a7412249b9b8310a0eaa6b6f3b260f32db",
-                "sha256:f67a03f40f722e13261791280f73068dbaf9dafcc335cbba644ccc8f892640e5"
+                "sha256:30975c6a7d7941dd646d00a23e5982db49beaa60c3920bb243727d43da805f12",
+                "sha256:dc935780da276a2ab31a7a08a8cf327a2ea47fa27e21d485073251a7eeb16167"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==5.4.1"
+            "version": "==5.4.2"
         },
         "qtpy": {
             "hashes": [

--- a/hwstats/__init__.py
+++ b/hwstats/__init__.py
@@ -7,4 +7,4 @@ HWSATS_PROJECT_DIR = Path(os.path.abspath(os.path.join(os.path.dirname(__file__)
 OUT_DIR = Path(os.path.join(HWSATS_PROJECT_DIR, "out"))
 os.makedirs(OUT_DIR, exist_ok=True)
 
-DB_PATH = Path(os.path.join(OUT_DIR, DB_NAME))
+DB_PATH = os.path.join(OUT_DIR, DB_NAME)

--- a/hwstats/backend.py
+++ b/hwstats/backend.py
@@ -1,5 +1,4 @@
 import logging
-from pathlib import Path
 
 from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Engine
@@ -7,10 +6,12 @@ from sqlalchemy.engine.base import Engine
 logger = logging.getLogger(__name__)
 
 
-def get_db_connection(database_path: Path) -> Engine:
+def get_db_connection(database_path: str) -> Engine:
     """
-    Get a connection to the database and if the database does not exist, create it.
+    Get a connection to the database. If the database does not exist, it will be created
+    once we try to write to it.
     Note that if you've changed the models, you'll need to delete the database file.
+    :param database_path: Absolute path to the database file
     :return: SQLAlchemy engine
     """
     logger.info(f"Connecting to database at {database_path}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,5 +30,8 @@ dependencies = [
 # Including this header will dynamically version the package based on the git tag
 [tool.setuptools_scm]
 
+[tool.setuptools]
+packages = ["hwstats"]
+
 [tool.black]
 line-length = 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import os
+
+import pytest
+
+from hwstats import OUT_DIR
+
+
+@pytest.fixture
+def db_path() -> str:
+    """Create a test database path"""
+    os.makedirs(OUT_DIR, exist_ok=True)
+    return os.path.join(OUT_DIR, "test.db")

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,14 +1,18 @@
 import os
-from pathlib import Path
 
 from sqlalchemy.engine.base import Engine
 
 from hwstats.backend import get_db_connection
+from hwstats.models import Base
 
 
-def test_get_db_connection(tmp_path: Path) -> None:
+def test_get_db_connection(db_path: str) -> None:
     """Test the get_db_connection function"""
-    database_path = tmp_path / "test.db"
-    engine = get_db_connection(database_path)
+    engine = get_db_connection(db_path)
+    # The db is not created until we call create_all
+    Base.metadata.create_all(engine)
     assert isinstance(engine, Engine)
-    assert os.path.exists(database_path)
+    assert os.path.exists(db_path)
+
+    # Cleanup
+    os.remove(db_path)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,14 @@
+import os
+from pathlib import Path
+
+from sqlalchemy.engine.base import Engine
+
+from hwstats.backend import get_db_connection
+
+
+def test_get_db_connection(tmp_path: Path) -> None:
+    """Test the get_db_connection function"""
+    database_path = tmp_path / "test.db"
+    engine = get_db_connection(database_path)
+    assert isinstance(engine, Engine)
+    assert os.path.exists(database_path)

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,0 +1,9 @@
+from hwstats.frontend import app
+
+
+def test_index() -> None:
+    """Test the index page"""
+    with app.test_client() as client:
+        response = client.get("/")
+        assert response.status_code == 200
+        assert b"Hardware Stats" in response.data


### PR DESCRIPTION
We issues installing `hw-stats` locally in editable mode. To fix, we simply needed to define the package for setuptools in the pyproject.toml. Along with a fix in the Makefile to put the venv in the project dir, we can now consistently build a dev environment. 

This PR also adds shared test fixtures and a test for the backend code.