### PR TITLE
Monitor bugfix

### DIFF
--- a/.github/workflows/PR-Acceptance.yml
+++ b/.github/workflows/PR-Acceptance.yml
@@ -30,5 +30,4 @@ jobs:
           pipenv run pylint $(git ls-files '*.py')
       - name: Test with pytest
         run: |
-          pipenv run pytest
           pipenv run pytest --cov

--- a/hwstats/frontend.py
+++ b/hwstats/frontend.py
@@ -3,7 +3,8 @@ import os
 import sys
 
 from flask import Flask, render_template
-from jinja2 import Environment, PackageLoader
+
+# from jinja2 import Environment, PackageLoader
 from plotly import graph_objects as go
 from plotly.graph_objects import Figure
 from plotly.subplots import make_subplots
@@ -48,8 +49,8 @@ def round_filter(value, precision=2):
 
 
 # Add the round function to the template environment's globals
-env = Environment(loader=PackageLoader(app.name, "templates"))
-env.filters["round"] = round_filter
+# env = Environment(loader=PackageLoader(app.name, "templates"))
+# env.filters["round"] = round_filter
 
 
 @app.route("/")

--- a/hwstats/models.py
+++ b/hwstats/models.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-import psutil
 import xxhash
 from psutil import Process
 from sqlalchemy import ForeignKey, String
@@ -95,52 +94,52 @@ def hash_process(process: Process) -> str:
     return xxhash.xxh3_64(str(process).encode("utf-8")).hexdigest()
 
 
-def build_cpu_from_process(process: Process) -> CPU:
+def build_cpu_from_process(process: dict) -> CPU:
     """Build CPU record object from a process"""
     return CPU(
-        pidHash=hash_process(process),
-        cpuPercent=process.cpu_percent(),
-        systemTime=process.cpu_times().system,
-        userTime=process.cpu_times().user,
-        threads=process.num_threads(),
+        pidHash=process["pidHash"],
+        cpuPercent=process["cpu_percent"],
+        systemTime=process["cpu_times"].system,
+        userTime=process["cpu_times"].user,
+        threads=process["num_threads"],
         # idleTime=process.cpu_times().idle,
         measurementTime=datetime.now(),
     )
 
 
-def build_memory_from_process(process: Process) -> Memory:
+def build_memory_from_process(process: dict) -> Memory:
     """Build Memory record object from a process"""
     return Memory(
-        pidHash=hash_process(process),
-        memoryPercent=process.memory_percent(),
-        memoryRSS=process.memory_info().rss,
+        pidHash=process["pidHash"],
+        memoryPercent=process["memory_percent"],
+        memoryRSS=process["memory_info"].rss,
         measurementTime=datetime.now(),
     )
 
 
-def build_disk_from_process(process: Process) -> Disk:
+def build_disk_from_process(process: dict) -> Disk:
     """Build Disk record object from a process"""
     try:
-        _diskRead = process.io_counters().read_count
-    except (PermissionError, psutil.AccessDenied):
+        _diskRead = process["io_counters"].read_count
+    except (PermissionError, AttributeError, KeyError):
         _diskRead = 0
     try:
-        _diskWrite = process.io_counters().write_count
-    except (PermissionError, psutil.AccessDenied):
+        _diskWrite = process["io_counters"].write_count
+    except (PermissionError, AttributeError, KeyError):
         _diskWrite = 0
     return Disk(
-        pidHash=hash_process(process),
+        pidHash=process["pidHash"],
         diskRead=_diskRead,
         diskWrite=_diskWrite,
         measurementTime=datetime.now(),
     )
 
 
-def build_sysprocess_from_process(process: Process) -> SysProcess:
+def build_sysprocess_from_process(process: dict) -> SysProcess:
     """Build a SysProcess record object from a process"""
     return SysProcess(
-        pidHash=hash_process(process),
-        pid=process.pid,
-        name=process.name(),
-        createTime=datetime.fromtimestamp(process.create_time()),
+        pidHash=process["pidHash"],
+        pid=process["pid"],
+        name=process["name"],
+        createTime=datetime.fromtimestamp(process["create_time"]),
     )

--- a/hwstats/monitor.py
+++ b/hwstats/monitor.py
@@ -64,10 +64,7 @@ def get_process_data(process: psutil.Process) -> tuple:
     # efficient than using the oneshot method directly, but for some reason calling the model build
     # methods seemed to exit the oneshot context manager and lead to bad data.
     process_dict = process.as_dict()
-
-    # Hash the process id, name, and create time to get a unique id for the process
-    id_str = f"{process_dict['pid']}, {process_dict['name']}, {process_dict['create_time']}"
-    process_dict["pidHash"] = xxhash.xxh64(id_str).hexdigest()
+    process_dict["pidHash"] = hash_process(process_dict)
 
     _sysprocess = models.build_sysprocess_from_process(process_dict)
     _cpu = models.build_cpu_from_process(process_dict)
@@ -97,3 +94,9 @@ def write_to_db(engine: Engine, data_queue: Queue, shutdown: Event, interval: fl
         session.commit()
         logger.debug("DB writer thread shutting down")
         return
+
+
+def hash_process(process_dict: dict) -> None:
+    """Hash the process id, name, and create time to get a unique id for the process"""
+    id_str = f"{process_dict['pid']}, {process_dict['name']}, {process_dict['create_time']}"
+    return xxhash.xxh64(id_str).hexdigest()

--- a/tests/test_cpu_load.py
+++ b/tests/test_cpu_load.py
@@ -9,8 +9,7 @@ from sqlalchemy.orm import Session
 
 from hwstats import COLLECTION_INTERVAL_SECONDS, models
 from hwstats.backend import get_cpu_percents_for_pidHash, get_db_connection
-from hwstats.models import hash_process
-from hwstats.monitor import start_metrics_collection
+from hwstats.monitor import hash_process, start_metrics_collection
 
 logger = logging.getLogger(__name__)
 
@@ -40,8 +39,9 @@ def test_cpu_load(db_path: str) -> None:
         # We need to wait for stress-ng to start it's child processes
         sleep(10)
         child_process = stress_process.children()[0]
+        child_process_dict = child_process.as_dict()
         print(stress_process.children())
-        stress_child_hash = hash_process(child_process)
+        stress_child_hash = hash_process(child_process_dict)
         print(f"Stress child hash is {stress_child_hash}")
         print(stress.stdout.read().decode("utf-8"))
         assert os.path.exists(db_path)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,27 +1,40 @@
 import psutil
+import xxhash
 
 import hwstats.models
 
 
 def test_sys_process_builder():
     """Test the SysProcess builder"""
-    process = hwstats.models.build_sysprocess_from_process(psutil.Process())
+    process_dict = psutil.Process().as_dict()
+    id_str = f"{process_dict['pid']}, {process_dict['name']}, {process_dict['create_time']}"
+    process_dict["pidHash"] = xxhash.xxh64(id_str).hexdigest()
+    process = hwstats.models.build_sysprocess_from_process(process_dict)
     assert isinstance(process, hwstats.models.SysProcess)
 
 
 def test_cpu_builder():
     """Test the SysProcess builder"""
-    process = hwstats.models.build_cpu_from_process(psutil.Process())
+    process_dict = psutil.Process().as_dict()
+    id_str = f"{process_dict['pid']}, {process_dict['name']}, {process_dict['create_time']}"
+    process_dict["pidHash"] = xxhash.xxh64(id_str).hexdigest()
+    process = hwstats.models.build_cpu_from_process(process_dict)
     assert isinstance(process, hwstats.models.CPU)
 
 
 def test_memory_builder():
     """Test the SysProcess builder"""
-    process = hwstats.models.build_memory_from_process(psutil.Process())
+    process_dict = psutil.Process().as_dict()
+    id_str = f"{process_dict['pid']}, {process_dict['name']}, {process_dict['create_time']}"
+    process_dict["pidHash"] = xxhash.xxh64(id_str).hexdigest()
+    process = hwstats.models.build_memory_from_process(process_dict)
     assert isinstance(process, hwstats.models.Memory)
 
 
 def test_disk_builder():
     """Test the SysProcess builder"""
-    process = hwstats.models.build_disk_from_process(psutil.Process())
+    process_dict = psutil.Process().as_dict()
+    id_str = f"{process_dict['pid']}, {process_dict['name']}, {process_dict['create_time']}"
+    process_dict["pidHash"] = xxhash.xxh64(id_str).hexdigest()
+    process = hwstats.models.build_disk_from_process(process_dict)
     assert isinstance(process, hwstats.models.Disk)


### PR DESCRIPTION
We've been using the psutil `oneshot` context manager method to read all
of the available metrics from a Process. This did not seem to work at
times and we would get processes who's metrics just had zeros. This
update instead uses the `to_dict` method so that the values are truely
frozen, and we can safely build ORM objects out of them.